### PR TITLE
Process uploaded property videos with FFmpeg

### DIFF
--- a/templates/user/feed.html
+++ b/templates/user/feed.html
@@ -103,7 +103,7 @@
       flex-direction: column;
       gap: 1.2rem;
       align-items: center;
-      transform: translateY(-40px);
+      transform: translateY(-50px);
     }
 
     .action-item {


### PR DESCRIPTION
Enhanced the property video upload workflow to move raw uploads to a dedicated folder, process them with FFmpeg for consistent encoding, and save only the processed video. Also updated the feed template to adjust vertical translation for better UI alignment.