### PR TITLE
Add favicon and page title to feed template

### DIFF
--- a/templates/user/feed.html
+++ b/templates/user/feed.html
@@ -5,6 +5,9 @@
 
 <head>
   <meta charset="utf-8" />
+  
+  <link rel="icon" href="{% static 'images/markblu-logo.png' %}" type="image/x-icon" />
+  <title>MarkBlu</title>
   <!-- Google Tag Manager -->
   <script>(function (w, d, s, l, i) {
       w[l] = w[l] || []; w[l].push({


### PR DESCRIPTION
Added a favicon and set the page title to 'MarkBlu' in the user feed template for improved branding and user experience.